### PR TITLE
Makefile fix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,6 @@ clean:
 	rm -f *.o pngtocss
 
 pngtocss: pngtocss.c
-	gcc -o pngtocss -g -I/opt/local/include -L/opt/local/lib -lpng -lz pngtocss.c
+	gcc -o pngtocss -g -I/opt/local/include -L/opt/local/lib pngtocss.c -lpng -lz
 
 .PHONY: all clean


### PR DESCRIPTION
The library linking flags are listed in the wrong order in the Makefile.  See http://gcc.gnu.org/onlinedocs/gcc/Link-Options.html for confirmation that the -l flags should go after the target.

GCC on Cygwin is very finicky about this, and won't link the libraries otherwise.  I have confirmed that it still builds for me on Ubuntu with the fixed Makefile.
