### PR TITLE
include zlib.h

### DIFF
--- a/src/pngtocss.c
+++ b/src/pngtocss.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <png.h>
+#include <zlib.h>
 
 #define VERSION "0.1"
 


### PR DESCRIPTION
libpng no longer include zlib.h itself so now included explicitly

Fixes build error:
pngtocss.c: In function ‘version_info’:
pngtocss.c:100: error: ‘ZLIB_VERSION’ undeclared (first use in this
function)
pngtocss.c:100: error: (Each undeclared identifier is reported only once
pngtocss.c:100: error: for each function it appears in.)
pngtocss.c:100: error: ‘zlib_version’ undeclared (first use in this
function)